### PR TITLE
Delimiter specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In it's latest incarnation NeoVipe offers the following on top of its base funct
 - Piping to stdout only continues if the file is saved in `$EDITOR`, otherwise an error is raised.
   - This behavior can be overriden by invoking NeoVipe with the `-p` or `--pipe-without-save` flags, though changes made in `$EDITOR` do not persist unless the file is saved.
 - Allows emitting filenames via the `-x` or `--output-file-name` flags for use with xargs and other similar tools.
+  - Specify a delimiter to append to the filename via the `-d` or `--delimiter` flag. Defaults to `\n` if unspecified.
 
 # Origin
 NeoVipe is adapted and updated from the following sources:

--- a/nvipe
+++ b/nvipe
@@ -192,6 +192,7 @@ if [ -z "${delimiter}" ]; then
       fi
     fi
     shift 1
+  elif printf "%s\n" "${1}" | grep -qE -- "(-t)|(--t(e(m(p(l(a(t(e)?)?)?)?)?)?)?)).*?"; then
     case "${1}" in
     *=*)
       leader="${1%%=*}="

--- a/nvipe
+++ b/nvipe
@@ -59,6 +59,7 @@ Options:
   -t, --template [TEMPLATE]	Specify template for naming temporary file buffer.
   -p, --pipe-without-saving	If present, exiting \$EDITOR without saving doesn't emit an error.
   -x, --output-file-name	If present, outputs temporary file name instead of contents.
+  -d, --delimiter		Sets delimiter emitted after filename when used in conjuction with file name output mode.
 
 Example:
 	printf "change me\n" > "my_input.txt"
@@ -82,6 +83,7 @@ main() {
   template="${1}"
   pipe_without_save="${2}"
   output_file_name="${3}"
+  delimiter="${4}"
   if tmp=$(mktemp -q -- "${TMPDIR:-/tmp}/${template}"); then # Create a temp file to act as a buffer for $EDITOR with adequate randomness to avoid race condition attacks, using user template if provided
     if [ "${output_file_name}" -eq 0 ]; then
       trap 'rm -rf "${tmp}"' EXIT HUP INT QUIT ABRT TERM # Removes the temp file when execution finishes, except on receipt of SIGKILL or if the filepath is meant to be output
@@ -95,7 +97,7 @@ main() {
       if [ "${output_file_name}" -eq 0 ]; then
         cat "${tmp}"
       else
-        printf "%s\n" "${tmp}"
+        printf "%s%b" "${tmp}" "${delimiter}"
       fi
       return 0
     else
@@ -111,6 +113,7 @@ main() {
 template="$(basename "${0}").XXXXXXXXXXXXXXXX" # Default template used when no user-provided template is present
 pipe_without_save=0                            # By default, nvipe emits an error if the user closes the temporary file without saving.
 output_file_name=0                             # By default, nvipe emits file contents instead of the path to the temporary file.
+delimiter="\n"                                 # By default, nvipe delimits filename output with a newline.
 
 while [ "${#}" -gt 0 ]; do
   if printf "%s\n" "${1}" | grep -qE -- "^(-h)|(--h(e(l(p)?)?)?)"; then
@@ -127,7 +130,68 @@ while [ "${#}" -gt 0 ]; do
   elif printf "%s\n" "${1}" | grep -qE -- "(-x)|(--o(u(t(p(u(t(-(f(i(l(e(-(n(a(m(e)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)"; then
     output_file_name=1
     shift 1
-  elif printf "%s\n" "${1}" | grep -qE -- "(-t.*?)|(--t(e(m(p(l(a(t(e)?)?)?)?)?)?)?)).*?"; then
+  elif printf "%s\n${1}" | grep -qE -- "(-d)|(--d(e(l(i(m(i(t(e(r)?)?)?)?)?)?)?)?).*?"; then
+    case "${1}" in
+    *=*)
+      leader="${1%%=*}="
+      delimiter="${1#"${leader}"}"
+      ;;
+    --delimiter*)
+      delimiter="${1#--delimiter}"
+      ;;
+    --delimiter*)
+      delimiter="${1#--delimiter}"
+      ;;
+    --delimite*)
+      delimiter="${1#--delimite}"
+      ;;
+    --delimit*)
+      delimiter="${1#--delimit}"
+      ;;
+    --delimi*)
+      delimiter="${1#--delimi}"
+      ;;
+    --delim*)
+      delimiter="${1#--delim}"
+      ;;
+    --deli*)
+      delimiter="${1#--deli}"
+      ;;
+    --del*)
+      delimiter="${1#--del}"
+      ;;
+    --de*)
+      delimiter="${1#--de}"
+      ;;
+    --d*)
+      delimiter="${1#--d}"
+      ;;
+    -d*)
+      delimiter="${1#-d}"
+      ;;
+    *)
+      printf "%s: invalid delimiter format -- '%s\n'" "$(basename "$0")" "${1}" >&2
+      return 2
+      ;;
+    esac
+if [ -z "${delimiter}" ]; then
+      if [ -n "${2}" ]; then
+        case "${2}" in
+        -*)
+          printf "%s: If '--delimiter' is specified, a delimiter string must be provided\n" "$(basename "$0")" >&2
+          return 2
+          ;;
+        *)
+          delimiter="${2}"
+          shift 1
+          ;;
+        esac
+      else
+        printf "%s: If '--delimiter' is specified, a delimiter string must be provided\n" "$(basename "$0")" >&2
+        return 2
+      fi
+    fi
+    shift 1
     case "${1}" in
     *=*)
       leader="${1%%=*}="
@@ -194,6 +258,6 @@ EOF
     return 2
   fi
 done
-main "${template}" "${pipe_without_save}" "${output_file_name}" || return "${?}"
+main "${template}" "${pipe_without_save}" "${output_file_name}" "${delimiter}" || return "${?}"
 
 # vim: set filetype=sh:

--- a/tests/test_neovipe.sh
+++ b/tests/test_neovipe.sh
@@ -79,6 +79,48 @@ flag_parsing() {
     failed_subtests=$((failed_subtests + 1))
   fi
 
+  printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name -d delimiter > /dev/null 2> /dev/null
+  status="${?}"
+  total_subtests=$((total_subtests + 1))
+  if ! assert_eq_num "${status}" 0; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+
+  printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name -d=delimiter > /dev/null 2> /dev/null
+  status="${?}"
+  total_subtests=$((total_subtests + 1))
+  if ! assert_eq_num "${status}" 0; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+
+  printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name -ddelimiter > /dev/null 2> /dev/null
+  status="${?}"
+  total_subtests=$((total_subtests + 1))
+  if ! assert_eq_num "${status}" 0; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+
+  printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name --delimiter delimiter > /dev/null 2> /dev/null
+  status="${?}"
+  total_subtests=$((total_subtests + 1))
+  if ! assert_eq_num "${status}" 0; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+
+  printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name --delimiter=delimiter > /dev/null 2> /dev/null
+  status="${?}"
+  total_subtests=$((total_subtests + 1))
+  if ! assert_eq_num "${status}" 0; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+
+  printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name --delimiter=delimiter > /dev/null 2> /dev/null
+  status="${?}"
+  total_subtests=$((total_subtests + 1))
+  if ! assert_eq_num "${status}" 0; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" -t nvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then

--- a/tests/test_neovipe.sh
+++ b/tests/test_neovipe.sh
@@ -71,6 +71,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name > /dev/null 2> /dev/null
   status="${?}"
@@ -78,6 +79,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name -d delimiter > /dev/null 2> /dev/null
   status="${?}"
@@ -85,6 +87,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name -d=delimiter > /dev/null 2> /dev/null
   status="${?}"
@@ -92,6 +95,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name -ddelimiter > /dev/null 2> /dev/null
   status="${?}"
@@ -99,6 +103,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name --delimiter delimiter > /dev/null 2> /dev/null
   status="${?}"
@@ -106,6 +111,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name --delimiter=delimiter > /dev/null 2> /dev/null
   status="${?}"
@@ -113,6 +119,7 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --output-file-name --delimiter=delimiter > /dev/null 2> /dev/null
   status="${?}"
@@ -120,48 +127,49 @@ flag_parsing() {
   if ! assert_eq_num "${status}" 0; then
     failed_subtests=$((failed_subtests + 1))
   fi
+  rm "${TMPDIR:-/tmp}"/nvipe*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" -t nvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" -t=nvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" -tnvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --template nvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --template=nvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --templatenvipe_temp.XXX --output-file-name > /dev/null 2> /dev/null
   total_subtests=$((total_subtests + 1))
   if ! ls "${TMPDIR:-/tmp}"/nvipe_temp.* > /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   if ! assert_eq_num "${failed_subtests}" 0; then
     printf "Failed %s subtests of %s.\n" "${failed_subtests}" "${total_subtests}" >&2
@@ -197,7 +205,7 @@ editing() {
   if ! printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --template=nvipe_temp.XXX --output-file-name | grep -q "nvipe_temp" > /dev/null 2> /dev/null; then
     failed_subtests=$((failed_subtests + 1))
   fi
-  rm -f "${TMPDIR:-/tmp}/nvipe_temp.*"
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
   if ! assert_eq_num "${failed_subtests}" 0; then
     printf "Failed %s subtests of %s.\n" "${failed_subtests}" "${total_subtests}" >&2

--- a/tests/test_neovipe.sh
+++ b/tests/test_neovipe.sh
@@ -207,6 +207,12 @@ editing() {
   fi
   rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
 
+  total_subtests=$((total_subtests + 1))
+  if ! printf "Please save and exit.\n" | "${NEOVIPE_PATH}" --template=nvipe_temp.XXX --output-file-name -d=^ | grep -q "^" > /dev/null 2> /dev/null; then
+    failed_subtests=$((failed_subtests + 1))
+  fi
+  rm -f "${TMPDIR:-/tmp}"/nvipe_temp.*
+
   if ! assert_eq_num "${failed_subtests}" 0; then
     printf "Failed %s subtests of %s.\n" "${failed_subtests}" "${total_subtests}" >&2
     return 1


### PR DESCRIPTION
Closes #9 by adding the -d flag, allowing specification of the delimiter appended to filenames when used in conjuction with the -x flag, alongside miscellaneous bugfixes.